### PR TITLE
Use form input name attribute instead of id for selecting values

### DIFF
--- a/braintree.js
+++ b/braintree.js
@@ -18,17 +18,17 @@
   Drupal.behaviors.braintree_payment.validateHandler = function(pmid, $method, submitter) {
     this.form_id = $method.closest('form').attr('id');
 
-    var ccn_id = '[id$=' + pmid + '-credit-card-number]';
-    var cvv_id = '[id$=' + pmid + '-secure-code]';
+    var ccn_name = '[name$="['+ pmid + '][credit_card_number]"]';
+    var cvv_name = '[name$="['+ pmid + '][secure_code]"]';
 
-    var ccn = $method.find(ccn_id)[0].value;
-    var cvv = $method.find(cvv_id)[0].value;
+    var ccn = $method.find(ccn_name)[0].value;
+    var cvv = $method.find(cvv_name)[0].value;
 
-    var expiry_month_id = '[id$=' + pmid + '-expiry-date-month]';
-    var expiry_year_id = '[id$=' + pmid + '-expiry-date-year]';
+    var expiry_month_name = '[name$="[' + pmid + '][expiry_date][month]"]';
+    var expiry_year_name = '[name$="[' + pmid + '][expiry_date][year]"]';
 
-    var expiry_month = $method.find(expiry_month_id)[0];
-    var expiry_year = $method.find(expiry_year_id)[0];
+    var expiry_month = $method.find(expiry_month_name)[0];
+    var expiry_year = $method.find(expiry_year_name)[0];
     var expiry_date = expiry_month.value + '/' + expiry_year.value;
 
     $('.mo-dialog-wrapper').addClass('visible');
@@ -81,10 +81,10 @@
         expiry_month = ''
         expiry_year = ''
         expiry_date = ''
-        $(ccn_id).val('');
-        $(cvv_id).val('');
-        $(expiry_month_id).val('');
-        $(expiry_year_id).val('');
+        $(ccn_name).val('');
+        $(cvv_name).val('');
+        $(expiry_month_name).val('');
+        $(expiry_year_name).val('');
 
         // Submit form
         submitter.ready();

--- a/braintree.js
+++ b/braintree.js
@@ -44,6 +44,19 @@
     braintree.client.create({
       authorization: this.settings[pmid].payment_token
     }, function(clientErr, clientInstance) {
+      if(clientErr) {
+        var detail_msg = clientErr.details.originalError.error.message;
+
+        if(detail_msg.length > 0) {
+          Drupal.behaviors.braintree_payment.errorHandler(detail_msg);
+        } else {
+          Drupal.behaviors.braintree_payment.errorHandler(requestErr);
+        }
+
+        submitter.error();
+        return;
+      }
+
       var data = {
         creditCard: {
           number: ccn,

--- a/braintree.js
+++ b/braintree.js
@@ -44,7 +44,7 @@
     braintree.client.create({
       authorization: this.settings[pmid].payment_token
     }, function(clientErr, clientInstance) {
-      if(clientErr) {
+      if (clientErr) {
         var detail_msg = clientErr.details.originalError.error.message;
 
         if(detail_msg.length > 0) {

--- a/braintree_payment.module
+++ b/braintree_payment.module
@@ -50,7 +50,7 @@ function braintree_payment_entity_load(array $entities, $entity_type) {
     while ($data = $result->fetchAssoc()) {
       $payment = $entities[$data['pid']];
       $payment->braintree = [
-        'id' => $data['braintree_id'],
+        'braintree_id' => $data['braintree_id'],
         'type' => $data['type'],
         'plan_id' => $data['plan_id'],
       ];

--- a/braintree_payment.module
+++ b/braintree_payment.module
@@ -5,7 +5,7 @@
  * Defines Credit Card Controller Information and libraries.
  */
 
-use \Drupal\braintree_payment\CreditCardController;
+use Drupal\braintree_payment\CreditCardController;
 
 /**
  * Implements hook_payment_method_controller_info().
@@ -59,8 +59,6 @@ function braintree_payment_entity_load(array $entities, $entity_type) {
 }
 
 /**
- * Implements hook_[ENTITY_TYPE]_[ACTION]().
- *
  * Implements hook_payment_insert().
  */
 function braintree_payment_payment_insert(Payment $payment) {
@@ -77,8 +75,6 @@ function braintree_payment_payment_insert(Payment $payment) {
 }
 
 /**
- * Implements hook_[ENTITY_TYPE]_[ACTION]().
- *
  * Implements hook_payment_update().
  */
 function braintree_payment_payment_update(Payment $payment) {
@@ -90,15 +86,13 @@ function braintree_payment_payment_update(Payment $payment) {
       'plan_id' => '',
     ];
     db_update('braintree_payment')
-     ->fields($data)
-     ->condition('pid', $payment->pid)
-     ->execute();
+      ->fields($data)
+      ->condition('pid', $payment->pid)
+      ->execute();
   }
 }
 
 /**
- * Implements hook_[ENTITY_TYPE]_[ACTION]().
- *
  * Implements hook_payment_delete().
  */
 function braintree_payment_payment_delete(Payment $payment) {


### PR DESCRIPTION
Form input IDs were used instead of form input names which resulted in errors on lines 30 and 31 in `braintree.js` if the form containing the payment method was submitted a second time.